### PR TITLE
Add file permission for ssh keys file

### DIFF
--- a/realsync
+++ b/realsync
@@ -414,7 +414,9 @@ sub do_install {
         print "Copying SSH key to $user\@$host. Executing:\n";
         my $cmd = "ssh"
             . " -o StrictHostKeyChecking=no -p$h_port $user\@$h_host\n"
-            . ' "cd; umask 077; test -d .ssh || mkdir .ssh; (echo; cat) >> .ssh/authorized_keys"';
+            . ' "cd; umask 077; test -d .ssh && chmod 700 .ssh || mkdir .ssh;'
+            . ' test -e .ssh/authorized_keys && chmod 600 .ssh/authorized_keys; (echo; cat)'
+            . ' >> .ssh/authorized_keys"';
         my $show = '$ ' . $cmd;
         print "$show\n";
         $cmd =~ s/\s*\n\s*/ /sg;


### PR DESCRIPTION
in case of DmitryKoterov/dklab_realsync#19 folder rights ~/ssh must be 700 and file rigths ~/ssh/authorized_keys must be 600